### PR TITLE
Update dependencies and resolve JODConverter breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ contains final result of those calculations.
 
 ### PDF Generation
 
-If you're on a system that uses an OpenOffice implementation of Excel, PDF 
+If you're on a system that uses a LibreOffice or Apache OpenOffice implementation of Excel, PDF 
 generation works the same was as creating a spreadsheet:
 
 ```clojure
@@ -250,4 +250,3 @@ For example, you can try:
 - A way to read in a saved workbook to the `{sheet-name [[cell]]}` format. I'm 
   not sure what the best way to extract style data is, since there are so many
   possible values.
-

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Lein:
     - [Grids](#grids)
     - [Templates](#templates)
 - [Roadmap](#roadmap)
+- [Development](#development)
+    - [Unit Tests](#unit-tests)
+    - [Office Integration Tests](#office-integration-tests)
+    - [All Tests](#all-tests)
 
 ## Getting Started
 
@@ -250,3 +254,26 @@ For example, you can try:
 - A way to read in a saved workbook to the `{sheet-name [[cell]]}` format. I'm 
   not sure what the best way to extract style data is, since there are so many
   possible values.
+
+## Development
+
+### Unit Tests
+
+Standard unit tests can be run with the following command:
+
+`$ lein test`
+
+### Office Integration Tests
+
+This test selector is designed to run tests that are dependent on the presence of LibreOffice or OpenOffice. 
+
+These tests can be run with:
+
+`$ lein test :office-integrations`
+
+### All Tests
+
+Run all tests with the following command:
+
+`$ lein test :all`
+ 

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,6 @@
                  [org.apache.poi/poi-ooxml "5.2.0"]
                  [org.jodconverter/jodconverter-local "4.4.2"]]
   :profiles {:test {:dependencies [[org.apache.logging.log4j/log4j-core "2.17.1"]
-                                   [org.slf4j/slf4j-nop "1.7.36"]]}})
+                                   [org.slf4j/slf4j-nop "1.7.36"]]}}
+  :test-selectors {:default             (complement :office-integrations)
+                   :office-integrations :office-integrations})

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,10 @@
   :url "https://github.com/matthewdowney/excel-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.taoensso/encore "3.12.1"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.taoensso/encore "3.21.0"]
                  [com.taoensso/tufte "2.2.0"]
-                 [org.apache.poi/poi-ooxml "4.1.2"]
-                 [org.jodconverter/jodconverter-core "4.0.0-RELEASE"]])
+                 [org.apache.poi/poi-ooxml "5.2.0"]
+                 [org.jodconverter/jodconverter-local "4.4.2"]]
+  :profiles {:test {:dependencies [[org.apache.logging.log4j/log4j-core "2.17.1"]
+                                   [org.slf4j/slf4j-nop "1.7.36"]]}})

--- a/test/excel_clj/core_test.clj
+++ b/test/excel_clj/core_test.clj
@@ -57,16 +57,3 @@
           (append! new-data template temp-file)))
       (finally
         (io/delete-file temp-file)))))
-
-
-(deftest convert-pdy-test
-  (let [temp-file (io/file (temp ".xlsx"))]
-    (try
-      (testing "Example code snippet writes successfully."
-        (println "Writing example template...")
-        (let [template (clojure.java.io/resource "uptime-template.xlsx")
-              new-data {"raw" (table-grid example-template-data)}]
-          (append! new-data template temp-file)))
-      (finally
-        (io/delete-file temp-file)))))
-

--- a/test/excel_clj/core_test.clj
+++ b/test/excel_clj/core_test.clj
@@ -54,6 +54,19 @@
         (println "Writing example template...")
         (let [template (clojure.java.io/resource "uptime-template.xlsx")
               new-data {"raw" (table-grid example-template-data)}]
-          (append! new-data template "filled-in-template.xlsx")))
+          (append! new-data template temp-file)))
       (finally
         (io/delete-file temp-file)))))
+
+
+(deftest convert-pdy-test
+  (let [temp-file (io/file (temp ".xlsx"))]
+    (try
+      (testing "Example code snippet writes successfully."
+        (println "Writing example template...")
+        (let [template (clojure.java.io/resource "uptime-template.xlsx")
+              new-data {"raw" (table-grid example-template-data)}]
+          (append! new-data template temp-file)))
+      (finally
+        (io/delete-file temp-file)))))
+

--- a/test/excel_clj/file_test.clj
+++ b/test/excel_clj/file_test.clj
@@ -1,0 +1,14 @@
+(ns excel-clj.file-test
+  (:require [clojure.test :refer :all]
+            [excel-clj.file :as file]
+            [clojure.java.io :as io]))
+
+(deftest convert-to-pdf-test
+  (let [input-file (clojure.java.io/resource "uptime-template.xlsx")
+        temp-pdf-file (io/file (file/temp ".pdf"))]
+    (try
+      (testing "Convert XLSX file to PDF"
+        (println "Writing example PDF...")
+        (file/convert-pdf! input-file temp-pdf-file))
+      (finally
+        (io/delete-file temp-pdf-file)))))

--- a/test/excel_clj/file_test.clj
+++ b/test/excel_clj/file_test.clj
@@ -3,7 +3,7 @@
             [excel-clj.file :as file]
             [clojure.java.io :as io]))
 
-(deftest convert-to-pdf-test
+(deftest ^:office-integrations convert-to-pdf-test
   (let [input-file (clojure.java.io/resource "uptime-template.xlsx")
         temp-pdf-file (io/file (file/temp ".pdf"))]
     (try

--- a/test/excel_clj/poi_test.clj
+++ b/test/excel_clj/poi_test.clj
@@ -11,7 +11,6 @@
          :success)
       "Example function writes successfully."))
 
-
 (deftest performance-test
   (testing "Performance is reasonable"
     (println "Starting performance test -- writing to a temp file...")


### PR DESCRIPTION
# Description

Update dependencies to mitigate known vulnerabilities. Migrated breaking JODConverter API changes between version 4.0.0-RELEASE and 4.1.0.


## Detected Vulnerabilities

Vulnerabilities detected via [Grype](https://github.com/anchore/grype)

| NAME             |  INSTALLED |  FIXED-IN |  VULNERABILITY       |  SEVERITY | 
| ---------------- |  --------- |  -------- |  ------------------- |  -------- | 
| commons-compress |  1.19      |  1.21     |  GHSA-7hfm-57qf-j43q |  High     |   
| commons-compress |  1.19      |  1.21     |  GHSA-crv7-7245-f45f |  High     |   
| commons-compress |  1.19      |  1.21     |  GHSA-mc84-pj99-q6hh |  High     |   
| commons-compress |  1.19      |  1.21     |  GHSA-xqfj-vm6h-2x34 |  High     |   
| commons-compress |  1.19      |           |  CVE-2021-35515      |  High     |   
| commons-compress |  1.19      |           |  CVE-2021-35516      |  High     |   
| commons-compress |  1.19      |           |  CVE-2021-35517      |  High     |   
| commons-compress |  1.19      |           |  CVE-2021-36090      |  High     |   
| commons-io       |  2.5       |  2.7      |  GHSA-gwrp-pvrq-jmwv |  Medium   |   
| commons-io       |  2.5       |           |  CVE-2021-29425      |  Medium   |

### Dependency Tree

commons-compress required by org.apache.poi/poi-ooxml 4.0.0

commons-io required by org.jodconverter/jodconverter-core 4.0.0-RELEASE


## Changes

1. Updated dependencies
2. Migrated JODConverter from 4.0.0-RELEASE to latest. Followed [migration](https://github.com/sbraconnier/jodconverter/wiki/Migration-Guide-4.1.0) steps for 4.1.0, replacing 
jodconverter-core dependency with jodconverter-local and replaced all library references to use jodconverter-local. 
3. Added test for PDF generation.
4. Added lein test profile to include logging dependencies with the intention of removing log warnings from the console when running tests:

    * log4j-core which is used by org.apache.poi/poi-ooxml since 5.1.0.
    * slf4j-nop which is used by org.jodconverter/jodconverter-local.


## Tests

Added excel-cli.file-test to handle pdf generation tests.
